### PR TITLE
fix dd-service silent failure

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -890,7 +890,7 @@ func installDupeDetection(ctx context.Context, config *configs.Config) (err erro
 		}
 	}
 
-	ddConfigPath := filepath.Join(targetDir, "config.ini")
+	ddConfigPath := filepath.Join(targetDir, constants.DupeDetectionConfigFilename)
 	err = utils.CreateFile(ctx, ddConfigPath, config.Force)
 	if err != nil {
 		log.WithContext(ctx).Errorf("Failed to create config.ini for dd-service : %s", ddConfigPath)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -388,7 +388,7 @@ func runDDService(ctx context.Context, config *configs.Config) (err error) {
 	}
 
 	ddConfigFilePath := filepath.Join(config.Configurer.GetHomeDir(),
-		"pastel_dupe_detection_service",
+		constants.DupeDetectionServiceDir,
 		constants.DupeDetectionSupportFilePath,
 		"config.ini")
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -390,7 +390,7 @@ func runDDService(ctx context.Context, config *configs.Config) (err error) {
 	ddConfigFilePath := filepath.Join(config.Configurer.GetHomeDir(),
 		constants.DupeDetectionServiceDir,
 		constants.DupeDetectionSupportFilePath,
-		"config.ini")
+		constants.DupeDetectionConfigFilename)
 
 	python := "python3"
 	if utils.GetOS() == constants.Windows {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -389,7 +389,7 @@ func runDDService(ctx context.Context, config *configs.Config) (err error) {
 
 	ddConfigFilePath := filepath.Join(config.Configurer.GetHomeDir(),
 		"pastel_dupe_detection_service",
-		"dupe_detection_support_files",
+		constants.DupeDetectionSupportFilePath,
 		"config.ini")
 
 	python := "python3"

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -2,6 +2,7 @@ package constants
 
 import (
 	"fmt"
+	"path/filepath"
 )
 
 // OSType - Windows, Linux, MAC, Unknown
@@ -223,12 +224,12 @@ var PastelRQServiceExecName = map[OSType]string{
 
 // DupeDetectionConfigs - dupe detection path of the supernode config
 var DupeDetectionConfigs = []string{
-	"dupe_detection_input_files",
-	"dupe_detection_support_files",
-	"dupe_detection_output_files",
-	"dupe_detection_processed_files",
-	"dupe_detection_rare_on_internet",
-	"mobilenet_v2_140_224",
+	"input_files",
+	DupeDetectionSupportFilePath,
+	"output_files",
+	"processed_files",
+	"rare_on_internet",
+	filepath.Join(DupeDetectionSupportFilePath, "mobilenet_v2_140_224"),
 }
 
 // DupeDetectionSupportDownloadURL - The URL of dupe detection support files
@@ -242,7 +243,7 @@ var DupeDetectionSupportDownloadURL = []string{
 }
 
 // DupeDetectionSupportFilePath - The target path for downloading dupe detection support files
-var DupeDetectionSupportFilePath = "dupe_detection_support_files"
+var DupeDetectionSupportFilePath = "support_files"
 
 // GetVersionSubURL returns the sub url concerned with version info
 func GetVersionSubURL(version string) string {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -66,6 +66,8 @@ const (
 	DupeDetectionArchiveName = "dupe-detection-server.zip"
 	// DupeDetectionSubFolder is the subfolder where dd scripts live
 	DupeDetectionSubFolder = "dd-service"
+	// DupeDetectionConfigFilename is the config file name for dd
+	DupeDetectionConfigFilename = "config.ini"
 	// DupeDetectionExecFileName  is exec name for dupe detection
 	DupeDetectionExecFileName = "dupe_detection_server.py"
 	// PortCheckURL is URL of port checker service


### PR DESCRIPTION
the dd-service start was failing silently earlier. This fixes that bug along with changing support files directory path from dupe_detection_support_files to support_files