### PR TITLE
Psl-94 / set supernode apps as systemd services

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1031,12 +1031,12 @@ func íntallAppService(ctx context.Context, appName string, config *configs.Conf
 			&configs.PasteldServerServiceScript{
 				PasteldBinaryPath: pastelDPath,
 				DataDir:           config.WorkingDir,
-				ExternalIp:        extIP,
+				ExternalIP:        extIP,
 			})
 
 		if err != nil {
-			log.WithContext(ctx).WithError(err).Error("unable to create content of dd_img_server file")
-			return fmt.Errorf("unable to create content of dd_img_server file - err: %s", err)
+			log.WithContext(ctx).WithError(err).Error("unable to create content of pasteld service file")
+			return fmt.Errorf("unable to create content of pasteld service file - err: %s", err)
 		}
 
 	case "supernode":

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path"
 	"path/filepath"
 	"strings"
@@ -956,6 +957,12 @@ func íntallAppService(ctx context.Context, appName string, config *configs.Conf
 	// Executable script - called by systemd service
 	appServiceStartFile := "start_" + appName + ".sh"
 
+	// Get current user that call the script
+	curUser, err := user.Current()
+	if err != nil {
+		return err
+	}
+
 	switch appName {
 	case "dd-img-server":
 		appServiceStartDir = filepath.Join(config.PastelExecDir, "dd-service")
@@ -1032,6 +1039,7 @@ func íntallAppService(ctx context.Context, appName string, config *configs.Conf
 				PasteldBinaryPath: pastelDPath,
 				DataDir:           config.WorkingDir,
 				ExternalIP:        extIP,
+				User:              curUser.Username,
 			})
 
 		if err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pastelnetwork/gonode/common/cli"
 	"github.com/pastelnetwork/gonode/common/errors"
@@ -1084,6 +1085,16 @@ func íntallAppService(ctx context.Context, appName string, config *configs.Conf
 	}
 
 	log.WithContext(ctx).Info(appName + " installed successfully")
+
+	// Check if service is already running
+	time.Sleep(3 * time.Second)
+	_, err = RunCMD("systemctl", "is-active", appName)
+	if err == nil {
+		log.WithContext(ctx).Infof(appName + " is running!")
+	} else {
+		log.WithContext(ctx).Infof(appName + " is FAILED to run, pls check detail: journalctl -u " + appName)
+	}
+
 	return nil
 }
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -892,10 +892,10 @@ func installDupeDetection(ctx context.Context, config *configs.Config) (err erro
 		}
 	}
 
-	ddBaseDir := filepath.Join(config.Configurer.DefaultHomeDir(), constants.DupeDetectionServiceDir)
+	appBaseDir := filepath.Join(config.Configurer.DefaultHomeDir(), constants.DupeDetectionServiceDir)
 	var pathList []interface{}
 	for _, configItem := range constants.DupeDetectionConfigs {
-		dupeDetectionDirPath := filepath.Join(ddBaseDir, configItem)
+		dupeDetectionDirPath := filepath.Join(appBaseDir, configItem)
 		if err = utils.CreateFolder(ctx, dupeDetectionDirPath, config.Force); err != nil {
 			log.WithContext(ctx).WithError(err).Errorf("Failed to create directory : %s", dupeDetectionDirPath)
 			return err

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -405,6 +405,12 @@ func runStartMasternode(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runRQService(ctx context.Context, config *configs.Config) error {
 
+	_, err := RunCMD("systemctl", "is-active", string(constants.RQService))
+	if err == nil {
+		log.WithContext(ctx).Infof(string(constants.RQService) + " is already running!")
+		return nil
+	}
+
 	rqExecName := constants.PastelRQServiceExecName[utils.GetOS()]
 
 	var rqServiceArgs []string
@@ -415,11 +421,19 @@ func runRQService(ctx context.Context, config *configs.Config) error {
 		log.WithContext(ctx).WithError(err).Error("rqservice failed")
 		return err
 	}
+
 	return nil
 }
 
 // Sub Command
 func runDDService(ctx context.Context, config *configs.Config) (err error) {
+
+	_, err = RunCMD("systemctl", "is-active", string(constants.DDService))
+	if err == nil {
+		log.WithContext(ctx).Infof(string(constants.DDService) + " is already running!")
+		return nil
+	}
+
 	log.WithContext(ctx).Infof("Starting dupe detection service")
 
 	var execPath string
@@ -477,6 +491,12 @@ func runWalletNodeService(ctx context.Context, config *configs.Config) error {
 
 // Sub Command
 func runSuperNodeService(ctx context.Context, config *configs.Config) error {
+
+	_, err := RunCMD("systemctl", "is-active", string(constants.SuperNode))
+	if err == nil {
+		log.WithContext(ctx).Infof(string(constants.SuperNode) + " is already running!")
+		return nil
+	}
 
 	supernodeConfigPath := config.Configurer.GetSuperNodeConfFile(config.WorkingDir)
 	supernodeExecName := constants.SuperNodeExecName[utils.GetOS()]
@@ -673,10 +693,15 @@ func prepareMasterNodeParameters(ctx context.Context, config *configs.Config) (e
 		bReIndex = flagReIndex
 	}
 
-	log.WithContext(ctx).Infof("Starting pasteld")
-	if err = runPastelNode(ctx, config, bReIndex, flagNodeExtIP, ""); err != nil {
-		log.WithContext(ctx).WithError(err).Error("pasteld failed to start")
-		return err
+	_, err = RunCMD("systemctl", "is-active", string(constants.PastelD))
+	if err == nil {
+		log.WithContext(ctx).Infof(string(constants.PastelD) + " is already running!")
+	} else {
+		log.WithContext(ctx).Infof("Starting pasteld")
+		if err = runPastelNode(ctx, config, bReIndex, flagNodeExtIP, ""); err != nil {
+			log.WithContext(ctx).WithError(err).Error("pasteld failed to start")
+			return err
+		}
 	}
 
 	// Check masternode status

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -405,9 +405,9 @@ func runStartMasternode(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runRQService(ctx context.Context, config *configs.Config) error {
 
-	_, err := RunCMD("systemctl", "is-active", string(constants.RQService))
+	err := checkServiceRunning(ctx, string(constants.RQService))
 	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.RQService) + " is already running!")
+		log.WithContext(ctx).Infof(string(constants.RQService) + " service is already running!")
 		return nil
 	}
 
@@ -428,9 +428,9 @@ func runRQService(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runDDService(ctx context.Context, config *configs.Config) (err error) {
 
-	_, err = RunCMD("systemctl", "is-active", string(constants.DDService))
+	err = checkServiceRunning(ctx, string(constants.DDService))
 	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.DDService) + " is already running!")
+		log.WithContext(ctx).Infof(string(constants.DDService) + " service is already running!")
 		return nil
 	}
 
@@ -492,9 +492,9 @@ func runWalletNodeService(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runSuperNodeService(ctx context.Context, config *configs.Config) error {
 
-	_, err := RunCMD("systemctl", "is-active", string(constants.SuperNode))
+	err := checkServiceRunning(ctx, string(constants.SuperNode))
 	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.SuperNode) + " is already running!")
+		log.WithContext(ctx).Infof(string(constants.SuperNode) + " service is already running!")
 		return nil
 	}
 
@@ -693,9 +693,9 @@ func prepareMasterNodeParameters(ctx context.Context, config *configs.Config) (e
 		bReIndex = flagReIndex
 	}
 
-	_, err = RunCMD("systemctl", "is-active", string(constants.PastelD))
+	err = checkServiceRunning(ctx, string(constants.PastelD))
 	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.PastelD) + " is already running!")
+		log.WithContext(ctx).Infof(string(constants.PastelD) + " service is already running!")
 	} else {
 		log.WithContext(ctx).Infof("Starting pasteld")
 		if err = runPastelNode(ctx, config, bReIndex, flagNodeExtIP, ""); err != nil {

--- a/configs/config.go
+++ b/configs/config.go
@@ -106,7 +106,7 @@ python3 -m  http.server 80`
 Description=Pasteld Daemon
 
 [Service]
-ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIp}}
+ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIP}}
 
 [Install]
 WantedBy=multi-user.target
@@ -160,10 +160,11 @@ type DDImgServerStartScript struct {
 	DDImgServerDir string
 }
 
+// PasteldServerServiceScript defines service file for /etc/systemd/system
 type PasteldServerServiceScript struct {
 	PasteldBinaryPath string
 	DataDir           string
-	ExternalIp        string
+	ExternalIP        string
 }
 
 // ZksnarkParamsNames - slice of zksnark parameters

--- a/configs/config.go
+++ b/configs/config.go
@@ -106,6 +106,7 @@ python3 -m  http.server 80`
 Description=Pasteld Daemon
 
 [Service]
+User={{.User}}
 ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIP}}
 
 [Install]
@@ -165,6 +166,7 @@ type PasteldServerServiceScript struct {
 	PasteldBinaryPath string
 	DataDir           string
 	ExternalIP        string
+	User              string
 }
 
 // ZksnarkParamsNames - slice of zksnark parameters

--- a/configs/config.go
+++ b/configs/config.go
@@ -100,6 +100,17 @@ WantedBy=multi-user.target
 	DDImgServerStart = `#!/bin/bash
 cd {{.DDImgServerDir}}
 python3 -m  http.server 80`
+
+	// PasteldServerService - /etc/systemd/system/pasteld.service
+	PasteldServerService = `[Unit]
+Description=Pasteld Daemon
+
+[Service]
+ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIp}}
+
+[Install]
+WantedBy=multi-user.target
+`
 )
 
 // WalletNodeConfig defines configurations for walletnode
@@ -147,6 +158,12 @@ type DDImgServerServiceScript struct {
 // DDImgServerStartScript actual script to start dd image server
 type DDImgServerStartScript struct {
 	DDImgServerDir string
+}
+
+type PasteldServerServiceScript struct {
+	PasteldBinaryPath string
+	DataDir           string
+	ExternalIp        string
 }
 
 // ZksnarkParamsNames - slice of zksnark parameters

--- a/configs/config.go
+++ b/configs/config.go
@@ -101,17 +101,18 @@ WantedBy=multi-user.target
 cd {{.DDImgServerDir}}
 python3 -m  http.server 80`
 
-	// PasteldServerService - /etc/systemd/system/pasteld.service
-	PasteldServerService = `[Unit]
-Description=Pasteld Daemon
-
-[Service]
-User={{.User}}
-ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIP}}
-
-[Install]
-WantedBy=multi-user.target
-`
+	// SystemdService - /etc/systemd/sysstem/rq-service.service
+	SystemdService = `[Unit]
+	Description={{.Desc}}
+	
+	[Service]
+	WorkingDirectory={{.WorkDir}}
+	User={{.User}}
+	ExecStart={{.ExecCmd}}
+	
+	[Install]
+	WantedBy=multi-user.target
+	`
 )
 
 // WalletNodeConfig defines configurations for walletnode
@@ -161,12 +162,12 @@ type DDImgServerStartScript struct {
 	DDImgServerDir string
 }
 
-// PasteldServerServiceScript defines service file for /etc/systemd/system
-type PasteldServerServiceScript struct {
-	PasteldBinaryPath string
-	DataDir           string
-	ExternalIP        string
-	User              string
+// SystemdServiceScript defines service file for /etc/systemd/system
+type SystemdServiceScript struct {
+	User    string
+	ExecCmd string
+	Desc    string
+	WorkDir string
 }
 
 // ZksnarkParamsNames - slice of zksnark parameters

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -85,6 +85,11 @@ const (
 	// DupeDetectionServiceDir defines location for dupe detection service
 	DupeDetectionServiceDir = "pastel_dupe_detection_service"
 
+	// SystemdServicePrefix prefix of all pastel services
+	SystemdServicePrefix = "pastel-"
+	// SystemdSystemDir location of systemd folder in Linux system
+	SystemdSystemDir = "/etc/systemd/system"
+
 	// RQServiceDir defines location for rq-service file exchange dir
 	RQServiceDir = "rqfiles"
 	// P2PDataDir defines location for p2p data dir


### PR DESCRIPTION
As supernode operator i want all supernode applications to be set as systemd services

TODO:

- [x] Modify func installDDImgServer in install.go to be reusable code to be applied for other services: pasted, supernode, rq-server, dd-server and dd-img-server
- [x] Ask user if they want to create system service to start pasteld, supernode, rq-server, dd-server
- [x] Implement and test pasteld
- [x] Implement service and test rq-server
- [x] Implement service and test dd-server
- [x] Implement service and test supernode
- [x] When doing 'start masternode' -- check if respective service is runninng
