### PR TITLE
Pastel-Utility Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,12 @@ The above command will:
 - start rq-server, dd-server and supernode
 
 ### Start supernode remotely
-TBD
 
+In order to install all extra packages and set system services, `password` of current user with `sudo` access is needed via param `--ssh-user-pw`.
+
+```
+./pastel-utility install supernode remote --ssh-ip <remote_ip> --ssh-dir=<path_remote_utility_folder>/ --utility-path-to-copy=<path_local_pastel-utility> --ssh-user=bacnh --ssh-user-pw=<remote_user_pw> --ssh-key=$HOME/.ssh/id_rsa 
+```
 
 ### Install command options
 
@@ -83,6 +87,7 @@ TBD
 - `--release value, -r value   Optional, Pastel version to install (default: "beta")`
 - `--started-remote            Optional, means that this command is executed remotely via ssh shell`
 - `--started-as-service        Optional, start all apps automatically as systemd service`
+- `--user-pw value             Optional, password of current sudo user - so no sudo password request is prompted`
 - `--help, -h                  show help (default: false)`
 
 ### Start command options

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ TBD
 - `--force, -f                 Optional, Force to overwrite config files and re-download ZKSnark parameters (default: false)`
 - `--peers value, -p value     Optional, List of peers to add into pastel.conf file, must be in the format - "ip" or "ip:port"`
 - `--release value, -r value   Optional, Pastel version to install (default: "beta")`
+- `--started-remote            Optional, means that this command is executed remotely via ssh shell`
+- `--started-as-service        Optional, start all apps automatically as systemd service`
 - `--help, -h                  show help (default: false)`
 
 ### Start command options

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1031,12 +1031,12 @@ func íntallAppService(ctx context.Context, appName string, config *configs.Conf
 			&configs.PasteldServerServiceScript{
 				PasteldBinaryPath: pastelDPath,
 				DataDir:           config.WorkingDir,
-				ExternalIp:        extIP,
+				ExternalIP:        extIP,
 			})
 
 		if err != nil {
-			log.WithContext(ctx).WithError(err).Error("unable to create content of dd_img_server file")
-			return fmt.Errorf("unable to create content of dd_img_server file - err: %s", err)
+			log.WithContext(ctx).WithError(err).Error("unable to create content of pasteld service file")
+			return fmt.Errorf("unable to create content of pasteld service file - err: %s", err)
 		}
 
 	case "supernode":

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path"
 	"path/filepath"
 	"strings"
@@ -956,6 +957,12 @@ func íntallAppService(ctx context.Context, appName string, config *configs.Conf
 	// Executable script - called by systemd service
 	appServiceStartFile := "start_" + appName + ".sh"
 
+	// Get current user that call the script
+	curUser, err := user.Current()
+	if err != nil {
+		return err
+	}
+
 	switch appName {
 	case "dd-img-server":
 		appServiceStartDir = filepath.Join(config.PastelExecDir, "dd-service")
@@ -1032,6 +1039,7 @@ func íntallAppService(ctx context.Context, appName string, config *configs.Conf
 				PasteldBinaryPath: pastelDPath,
 				DataDir:           config.WorkingDir,
 				ExternalIP:        extIP,
+				User:              curUser.Username,
 			})
 
 		if err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -560,6 +560,14 @@ func runComponentsInstall(ctx context.Context, config *configs.Config, installCo
 		}
 	}
 
+	// Install node as service
+	if (installCommand == constants.PastelD) && (config.StartedAsService) {
+		if err := installAppService(ctx, string(constants.PastelD), config); err != nil {
+			log.WithContext(ctx).WithError(err).Error("Failed to install " + appName + " service")
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pastelnetwork/gonode/common/cli"
 	"github.com/pastelnetwork/gonode/common/errors"
@@ -1084,6 +1085,16 @@ func íntallAppService(ctx context.Context, appName string, config *configs.Conf
 	}
 
 	log.WithContext(ctx).Info(appName + " installed successfully")
+
+	// Check if service is already running
+	time.Sleep(3 * time.Second)
+	_, err = RunCMD("systemctl", "is-active", appName)
+	if err == nil {
+		log.WithContext(ctx).Infof(appName + " is running!")
+	} else {
+		log.WithContext(ctx).Infof(appName + " is FAILED to run, pls check detail: journalctl -u " + appName)
+	}
+
 	return nil
 }
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -892,10 +892,10 @@ func installDupeDetection(ctx context.Context, config *configs.Config) (err erro
 		}
 	}
 
-	ddBaseDir := filepath.Join(config.Configurer.DefaultHomeDir(), constants.DupeDetectionServiceDir)
+	appBaseDir := filepath.Join(config.Configurer.DefaultHomeDir(), constants.DupeDetectionServiceDir)
 	var pathList []interface{}
 	for _, configItem := range constants.DupeDetectionConfigs {
-		dupeDetectionDirPath := filepath.Join(ddBaseDir, configItem)
+		dupeDetectionDirPath := filepath.Join(appBaseDir, configItem)
 		if err = utils.CreateFolder(ctx, dupeDetectionDirPath, config.Force); err != nil {
 			log.WithContext(ctx).WithError(err).Errorf("Failed to create directory : %s", dupeDetectionDirPath)
 			return err

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -55,6 +55,8 @@ func setupSubCommand(config *configs.Config,
 			SetUsage(green("Optional, Pastel version to install")).SetValue("beta"),
 		cli.NewFlag("started-remote", &config.StartedRemote).
 			SetUsage(green("Optional, means that this command is executed remotely via ssh shell")),
+		cli.NewFlag("started-as-service", &config.StartedAsService).
+			SetUsage(green("Optional, start all apps automatically as systemd service")),
 	}
 
 	var dirsFlags []*cli.Flag
@@ -442,16 +444,13 @@ func runComponentsInstall(ctx context.Context, config *configs.Config, installCo
 		}
 
 		// Start all wallet nodes apps as service
-		// installAppsAsService - pasteld, supernode, rq-server, dd-server
-		appServiceNames := []string{
-			string(constants.PastelD),
-			string(constants.RQService),
-			string(constants.WalletNode),
-		}
+		if config.StartedAsService {
+			appServiceNames := []string{
+				string(constants.PastelD),
+				string(constants.RQService),
+				string(constants.WalletNode),
+			}
 
-		yes, _ := AskUserToContinue(ctx, "Do you want to to set all applications - pasteld, rqservice, walletnode as service? (Y/N)")
-
-		if yes {
 			for _, appName := range appServiceNames {
 				if err = installAppService(ctx, appName, config); err != nil {
 					log.WithContext(ctx).WithError(err).Error("Failed to install " + appName + " service")
@@ -544,16 +543,14 @@ func runComponentsInstall(ctx context.Context, config *configs.Config, installCo
 		}
 
 		// installAppsAsService - pasteld, supernode, rq-server, dd-server
-		appServiceNames := []string{
-			string(constants.PastelD),
-			string(constants.RQService),
-			string(constants.DDService),
-			string(constants.SuperNode),
-		}
+		if config.StartedAsService {
+			appServiceNames := []string{
+				string(constants.PastelD),
+				string(constants.RQService),
+				string(constants.DDService),
+				string(constants.SuperNode),
+			}
 
-		yes, _ := AskUserToContinue(ctx, "Do you want to to set all applications - pasteld, supernode, rq-server and dd-server as service? (Y/N)")
-
-		if yes {
 			for _, appName := range appServiceNames {
 				if err = installAppService(ctx, appName, config); err != nil {
 					log.WithContext(ctx).WithError(err).Error("Failed to install " + appName + " service")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -405,21 +405,17 @@ func runStartMasternode(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runRQService(ctx context.Context, config *configs.Config) error {
 
-	err := checkServiceRunning(ctx, string(constants.RQService))
-	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.RQService) + " service is already running!")
-		return nil
-	}
+	if err := startService(ctx, string(constants.RQService)); err != nil {
+		rqExecName := constants.PastelRQServiceExecName[utils.GetOS()]
 
-	rqExecName := constants.PastelRQServiceExecName[utils.GetOS()]
+		var rqServiceArgs []string
+		rqServiceArgs = append(rqServiceArgs,
+			fmt.Sprintf("--config-file=%s", config.Configurer.GetRQServiceConfFile(config.WorkingDir)))
 
-	var rqServiceArgs []string
-	rqServiceArgs = append(rqServiceArgs,
-		fmt.Sprintf("--config-file=%s", config.Configurer.GetRQServiceConfFile(config.WorkingDir)))
-
-	if err := runPastelService(ctx, config, constants.RQService, rqExecName, rqServiceArgs...); err != nil {
-		log.WithContext(ctx).WithError(err).Error("rqservice failed")
-		return err
+		if err := runPastelService(ctx, config, constants.RQService, rqExecName, rqServiceArgs...); err != nil {
+			log.WithContext(ctx).WithError(err).Error("rqservice failed")
+			return err
+		}
 	}
 
 	return nil
@@ -428,41 +424,37 @@ func runRQService(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runDDService(ctx context.Context, config *configs.Config) (err error) {
 
-	err = checkServiceRunning(ctx, string(constants.DDService))
-	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.DDService) + " service is already running!")
-		return nil
-	}
+	if err := startService(ctx, string(constants.DDService)); err != nil {
+		log.WithContext(ctx).Infof("Starting dupe detection service")
 
-	log.WithContext(ctx).Infof("Starting dupe detection service")
+		var execPath string
+		if execPath, err = checkPastelFilePath(ctx, config.PastelExecDir, utils.GetDupeDetectionExecName()); err != nil {
+			log.WithContext(ctx).WithError(err).Error("Could not find dupe detection service script")
+			return err
+		}
 
-	var execPath string
-	if execPath, err = checkPastelFilePath(ctx, config.PastelExecDir, utils.GetDupeDetectionExecName()); err != nil {
-		log.WithContext(ctx).WithError(err).Error("Could not find dupe detection service script")
-		return err
-	}
+		ddConfigFilePath := filepath.Join(config.Configurer.DefaultHomeDir(),
+			constants.DupeDetectionServiceDir,
+			constants.DupeDetectionSupportFilePath,
+			constants.DupeDetectionConfigFilename)
 
-	ddConfigFilePath := filepath.Join(config.Configurer.DefaultHomeDir(),
-		constants.DupeDetectionServiceDir,
-		constants.DupeDetectionSupportFilePath,
-		constants.DupeDetectionConfigFilename)
+		python := "python3"
+		if utils.GetOS() == constants.Windows {
+			python = "python"
+		}
+		go RunCMD(python, execPath, ddConfigFilePath)
 
-	python := "python3"
-	if utils.GetOS() == constants.Windows {
-		python = "python"
-	}
-	go RunCMD(python, execPath, ddConfigFilePath)
+		time.Sleep(10 * time.Second)
 
-	time.Sleep(10 * time.Second)
-
-	if output, err := FindRunningProcess(constants.DupeDetectionExecFileName); len(output) == 0 {
-		err = errors.Errorf("dd-service failed to start")
-		log.WithContext(ctx).WithError(err).Error("dd-service failed to start")
-		return err
-	} else if err != nil {
-		log.WithContext(ctx).WithError(err).Error("failed to test if dd-servise is running")
-	} else {
-		log.WithContext(ctx).Info("dd-service is successfully started")
+		if output, err := FindRunningProcess(constants.DupeDetectionExecFileName); len(output) == 0 {
+			err = errors.Errorf("dd-service failed to start")
+			log.WithContext(ctx).WithError(err).Error("dd-service failed to start")
+			return err
+		} else if err != nil {
+			log.WithContext(ctx).WithError(err).Error("failed to test if dd-servise is running")
+		} else {
+			log.WithContext(ctx).Info("dd-service is successfully started")
+		}
 	}
 
 	return nil
@@ -470,57 +462,61 @@ func runDDService(ctx context.Context, config *configs.Config) (err error) {
 
 // Sub Command
 func runWalletNodeService(ctx context.Context, config *configs.Config) error {
-	err := checkServiceRunning(ctx, string(constants.WalletNode))
-	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.WalletNode) + " service is already running!")
-		return nil
+
+	err := startService(ctx, string(constants.WalletNode))
+	if err != nil {
+		walletnodeExecName := constants.WalletNodeExecName[utils.GetOS()]
+		log.WithContext(ctx).Infof("Starting walletnode service - %s", walletnodeExecName)
+
+		var wnServiceArgs []string
+		wnServiceArgs = append(wnServiceArgs,
+			fmt.Sprintf("--config-file=%s", config.Configurer.GetWalletNodeConfFile(config.WorkingDir)))
+		if flagDevMode {
+			wnServiceArgs = append(wnServiceArgs, "--swagger")
+		}
+
+		log.WithContext(ctx).Infof("Options : %s", wnServiceArgs)
+		if err := runPastelService(ctx, config, constants.WalletNode, walletnodeExecName, wnServiceArgs...); err != nil {
+			log.WithContext(ctx).WithError(err).Error("walletnode service failed")
+			return err
+		}
 	}
 
-	walletnodeExecName := constants.WalletNodeExecName[utils.GetOS()]
-	log.WithContext(ctx).Infof("Starting walletnode service - %s", walletnodeExecName)
-
-	var wnServiceArgs []string
-	wnServiceArgs = append(wnServiceArgs,
-		fmt.Sprintf("--config-file=%s", config.Configurer.GetWalletNodeConfFile(config.WorkingDir)))
-	if flagDevMode {
-		wnServiceArgs = append(wnServiceArgs, "--swagger")
-	}
-
-	log.WithContext(ctx).Infof("Options : %s", wnServiceArgs)
-	if err := runPastelService(ctx, config, constants.WalletNode, walletnodeExecName, wnServiceArgs...); err != nil {
-		log.WithContext(ctx).WithError(err).Error("walletnode service failed")
-		return err
-	}
 	return nil
 }
 
 // Sub Command
 func runSuperNodeService(ctx context.Context, config *configs.Config) error {
 
-	err := checkServiceRunning(ctx, string(constants.SuperNode))
-	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.SuperNode) + " service is already running!")
-		return nil
+	err := startService(ctx, string(constants.SuperNode))
+	if err != nil {
+		supernodeConfigPath := config.Configurer.GetSuperNodeConfFile(config.WorkingDir)
+		supernodeExecName := constants.SuperNodeExecName[utils.GetOS()]
+		log.WithContext(ctx).Infof("Starting Supernode service - %s", supernodeExecName)
+
+		var snServiceArgs []string
+		snServiceArgs = append(snServiceArgs,
+			fmt.Sprintf("--config-file=%s", supernodeConfigPath))
+
+		log.WithContext(ctx).Infof("Options : %s", snServiceArgs)
+		if err := runPastelService(ctx, config, constants.SuperNode, supernodeExecName, snServiceArgs...); err != nil {
+			log.WithContext(ctx).WithError(err).Error("supernode failed")
+			return err
+		}
 	}
 
-	supernodeConfigPath := config.Configurer.GetSuperNodeConfFile(config.WorkingDir)
-	supernodeExecName := constants.SuperNodeExecName[utils.GetOS()]
-	log.WithContext(ctx).Infof("Starting Supernode service - %s", supernodeExecName)
-
-	var snServiceArgs []string
-	snServiceArgs = append(snServiceArgs,
-		fmt.Sprintf("--config-file=%s", supernodeConfigPath))
-
-	log.WithContext(ctx).Infof("Options : %s", snServiceArgs)
-	if err := runPastelService(ctx, config, constants.SuperNode, supernodeExecName, snServiceArgs...); err != nil {
-		log.WithContext(ctx).WithError(err).Error("supernode failed")
-		return err
-	}
 	return nil
 }
 
 ///// Run helpers
 func runPastelNode(ctx context.Context, config *configs.Config, reindex bool, extIP string, mnPrivKey string) (err error) {
+	// Start Pasteld service
+	err = startService(ctx, string(constants.PastelD))
+	if err == nil {
+		log.WithContext(ctx).Info("Pasteld is already running!")
+		return nil
+	}
+
 	var pastelDPath string
 
 	if pastelDPath, err = checkPastelFilePath(ctx, config.PastelExecDir, constants.PasteldName[utils.GetOS()]); err != nil {
@@ -698,7 +694,7 @@ func prepareMasterNodeParameters(ctx context.Context, config *configs.Config) (e
 		bReIndex = flagReIndex
 	}
 
-	err = checkServiceRunning(ctx, string(constants.PastelD))
+	err = checkServiceRunning(string(constants.PastelD))
 	if err == nil {
 		log.WithContext(ctx).Infof(string(constants.PastelD) + " service is already running!")
 	} else {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -513,7 +513,7 @@ func runPastelNode(ctx context.Context, config *configs.Config, reindex bool, ex
 	// Start Pasteld service
 	err = startSystemdService(ctx, string(constants.PastelD))
 	if err == nil {
-		log.WithContext(ctx).Info("Pasteld is already running!")
+		log.WithContext(ctx).Info("Pasteld service is running!")
 		return nil
 	}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -405,7 +405,7 @@ func runStartMasternode(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runRQService(ctx context.Context, config *configs.Config) error {
 
-	if err := startService(ctx, string(constants.RQService)); err != nil {
+	if err := startSystemdService(ctx, string(constants.RQService)); err != nil {
 		rqExecName := constants.PastelRQServiceExecName[utils.GetOS()]
 
 		var rqServiceArgs []string
@@ -424,7 +424,7 @@ func runRQService(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runDDService(ctx context.Context, config *configs.Config) (err error) {
 
-	if err := startService(ctx, string(constants.DDService)); err != nil {
+	if err := startSystemdService(ctx, string(constants.DDService)); err != nil {
 		log.WithContext(ctx).Infof("Starting dupe detection service")
 
 		var execPath string
@@ -463,7 +463,7 @@ func runDDService(ctx context.Context, config *configs.Config) (err error) {
 // Sub Command
 func runWalletNodeService(ctx context.Context, config *configs.Config) error {
 
-	err := startService(ctx, string(constants.WalletNode))
+	err := startSystemdService(ctx, string(constants.WalletNode))
 	if err != nil {
 		walletnodeExecName := constants.WalletNodeExecName[utils.GetOS()]
 		log.WithContext(ctx).Infof("Starting walletnode service - %s", walletnodeExecName)
@@ -488,7 +488,7 @@ func runWalletNodeService(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runSuperNodeService(ctx context.Context, config *configs.Config) error {
 
-	err := startService(ctx, string(constants.SuperNode))
+	err := startSystemdService(ctx, string(constants.SuperNode))
 	if err != nil {
 		supernodeConfigPath := config.Configurer.GetSuperNodeConfFile(config.WorkingDir)
 		supernodeExecName := constants.SuperNodeExecName[utils.GetOS()]
@@ -511,7 +511,7 @@ func runSuperNodeService(ctx context.Context, config *configs.Config) error {
 ///// Run helpers
 func runPastelNode(ctx context.Context, config *configs.Config, reindex bool, extIP string, mnPrivKey string) (err error) {
 	// Start Pasteld service
-	err = startService(ctx, string(constants.PastelD))
+	err = startSystemdService(ctx, string(constants.PastelD))
 	if err == nil {
 		log.WithContext(ctx).Info("Pasteld is already running!")
 		return nil

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -405,6 +405,12 @@ func runStartMasternode(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runRQService(ctx context.Context, config *configs.Config) error {
 
+	_, err := RunCMD("systemctl", "is-active", string(constants.RQService))
+	if err == nil {
+		log.WithContext(ctx).Infof(string(constants.RQService) + " is already running!")
+		return nil
+	}
+
 	rqExecName := constants.PastelRQServiceExecName[utils.GetOS()]
 
 	var rqServiceArgs []string
@@ -415,11 +421,19 @@ func runRQService(ctx context.Context, config *configs.Config) error {
 		log.WithContext(ctx).WithError(err).Error("rqservice failed")
 		return err
 	}
+
 	return nil
 }
 
 // Sub Command
 func runDDService(ctx context.Context, config *configs.Config) (err error) {
+
+	_, err = RunCMD("systemctl", "is-active", string(constants.DDService))
+	if err == nil {
+		log.WithContext(ctx).Infof(string(constants.DDService) + " is already running!")
+		return nil
+	}
+
 	log.WithContext(ctx).Infof("Starting dupe detection service")
 
 	var execPath string
@@ -477,6 +491,12 @@ func runWalletNodeService(ctx context.Context, config *configs.Config) error {
 
 // Sub Command
 func runSuperNodeService(ctx context.Context, config *configs.Config) error {
+
+	_, err := RunCMD("systemctl", "is-active", string(constants.SuperNode))
+	if err == nil {
+		log.WithContext(ctx).Infof(string(constants.SuperNode) + " is already running!")
+		return nil
+	}
 
 	supernodeConfigPath := config.Configurer.GetSuperNodeConfFile(config.WorkingDir)
 	supernodeExecName := constants.SuperNodeExecName[utils.GetOS()]
@@ -673,10 +693,15 @@ func prepareMasterNodeParameters(ctx context.Context, config *configs.Config) (e
 		bReIndex = flagReIndex
 	}
 
-	log.WithContext(ctx).Infof("Starting pasteld")
-	if err = runPastelNode(ctx, config, bReIndex, flagNodeExtIP, ""); err != nil {
-		log.WithContext(ctx).WithError(err).Error("pasteld failed to start")
-		return err
+	_, err = RunCMD("systemctl", "is-active", string(constants.PastelD))
+	if err == nil {
+		log.WithContext(ctx).Infof(string(constants.PastelD) + " is already running!")
+	} else {
+		log.WithContext(ctx).Infof("Starting pasteld")
+		if err = runPastelNode(ctx, config, bReIndex, flagNodeExtIP, ""); err != nil {
+			log.WithContext(ctx).WithError(err).Error("pasteld failed to start")
+			return err
+		}
 	}
 
 	// Check masternode status

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -470,6 +470,11 @@ func runDDService(ctx context.Context, config *configs.Config) (err error) {
 
 // Sub Command
 func runWalletNodeService(ctx context.Context, config *configs.Config) error {
+	err := checkServiceRunning(ctx, string(constants.WalletNode))
+	if err == nil {
+		log.WithContext(ctx).Infof(string(constants.WalletNode) + " service is already running!")
+		return nil
+	}
 
 	walletnodeExecName := constants.WalletNodeExecName[utils.GetOS()]
 	log.WithContext(ctx).Infof("Starting walletnode service - %s", walletnodeExecName)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -405,9 +405,9 @@ func runStartMasternode(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runRQService(ctx context.Context, config *configs.Config) error {
 
-	_, err := RunCMD("systemctl", "is-active", string(constants.RQService))
+	err := checkServiceRunning(ctx, string(constants.RQService))
 	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.RQService) + " is already running!")
+		log.WithContext(ctx).Infof(string(constants.RQService) + " service is already running!")
 		return nil
 	}
 
@@ -428,9 +428,9 @@ func runRQService(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runDDService(ctx context.Context, config *configs.Config) (err error) {
 
-	_, err = RunCMD("systemctl", "is-active", string(constants.DDService))
+	err = checkServiceRunning(ctx, string(constants.DDService))
 	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.DDService) + " is already running!")
+		log.WithContext(ctx).Infof(string(constants.DDService) + " service is already running!")
 		return nil
 	}
 
@@ -492,9 +492,9 @@ func runWalletNodeService(ctx context.Context, config *configs.Config) error {
 // Sub Command
 func runSuperNodeService(ctx context.Context, config *configs.Config) error {
 
-	_, err := RunCMD("systemctl", "is-active", string(constants.SuperNode))
+	err := checkServiceRunning(ctx, string(constants.SuperNode))
 	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.SuperNode) + " is already running!")
+		log.WithContext(ctx).Infof(string(constants.SuperNode) + " service is already running!")
 		return nil
 	}
 
@@ -693,9 +693,9 @@ func prepareMasterNodeParameters(ctx context.Context, config *configs.Config) (e
 		bReIndex = flagReIndex
 	}
 
-	_, err = RunCMD("systemctl", "is-active", string(constants.PastelD))
+	err = checkServiceRunning(ctx, string(constants.PastelD))
 	if err == nil {
-		log.WithContext(ctx).Infof(string(constants.PastelD) + " is already running!")
+		log.WithContext(ctx).Infof(string(constants.PastelD) + " service is already running!")
 	} else {
 		log.WithContext(ctx).Infof("Starting pasteld")
 		if err = runPastelNode(ctx, config, bReIndex, flagNodeExtIP, ""); err != nil {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -142,7 +142,7 @@ func runStopWalletSubCommand(ctx context.Context, config *configs.Config) {
 	stopService(ctx, constants.RQService)
 
 	// *************  Stop pasteld node  *************
-	stopService(ctx, constants.PastelD)
+	stopPatelCLI(ctx, config)
 
 	log.WithContext(ctx).Info("Walletnode stopped successfully")
 }
@@ -163,7 +163,7 @@ func runStopSuperNodeSubCommand(ctx context.Context, config *configs.Config) {
 	stopService(ctx, constants.DDImgService)
 
 	// *************  Stop pasteld node  *************
-	stopService(ctx, constants.PastelD)
+	stopPatelCLI(ctx, config)
 
 	log.WithContext(ctx).Info("Suppernode stopped successfully")
 }
@@ -186,7 +186,7 @@ func runStopAllSubCommand(ctx context.Context, config *configs.Config) {
 	stopService(ctx, constants.DDImgService)
 
 	// *************  Stop pasteld node  *************
-	stopService(ctx, constants.PastelD)
+	stopPatelCLI(ctx, config)
 
 	log.WithContext(ctx).Info("All stopped successfully")
 }
@@ -208,15 +208,19 @@ func stopSNServiceSubCommand(ctx context.Context, _ *configs.Config) {
 }
 
 func stopPatelCLI(ctx context.Context, config *configs.Config) {
+
 	log.WithContext(ctx).Info("Stopping Pasteld")
-	if _, err := RunPastelCLI(ctx, config, "stop"); err != nil {
-		log.WithContext(ctx).WithError(err).Errorf("Failed to run '%s/pastel-cli stop'", config.WorkingDir)
-	}
-	time.Sleep(1 * time.Second)
-	if CheckProcessRunning(constants.PastelD) {
-		log.WithContext(ctx).Warn("Failed to stop pasted using 'pastel-cli stop'")
-	} else {
-		log.WithContext(ctx).Info("Pasteld stopped")
+
+	if err := stopSystemdService(ctx, string(constants.PastelD)); err != nil {
+		if _, err := RunPastelCLI(ctx, config, "stop"); err != nil {
+			log.WithContext(ctx).WithError(err).Errorf("Failed to run '%s/pastel-cli stop'", config.WorkingDir)
+		}
+		time.Sleep(1 * time.Second)
+		if CheckProcessRunning(constants.PastelD) {
+			log.WithContext(ctx).Warn("Failed to stop pasted using 'pastel-cli stop'")
+		} else {
+			log.WithContext(ctx).Info("Pasteld stopped")
+		}
 	}
 }
 

--- a/configs/config.go
+++ b/configs/config.go
@@ -106,7 +106,7 @@ python3 -m  http.server 80`
 Description=Pasteld Daemon
 
 [Service]
-ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIp}}
+ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIP}}
 
 [Install]
 WantedBy=multi-user.target
@@ -160,10 +160,11 @@ type DDImgServerStartScript struct {
 	DDImgServerDir string
 }
 
+// PasteldServerServiceScript defines service file for /etc/systemd/system
 type PasteldServerServiceScript struct {
 	PasteldBinaryPath string
 	DataDir           string
-	ExternalIp        string
+	ExternalIP        string
 }
 
 // ZksnarkParamsNames - slice of zksnark parameters

--- a/configs/config.go
+++ b/configs/config.go
@@ -106,6 +106,7 @@ python3 -m  http.server 80`
 Description=Pasteld Daemon
 
 [Service]
+User={{.User}}
 ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIP}}
 
 [Install]
@@ -165,6 +166,7 @@ type PasteldServerServiceScript struct {
 	PasteldBinaryPath string
 	DataDir           string
 	ExternalIP        string
+	User              string
 }
 
 // ZksnarkParamsNames - slice of zksnark parameters

--- a/configs/config.go
+++ b/configs/config.go
@@ -100,6 +100,17 @@ WantedBy=multi-user.target
 	DDImgServerStart = `#!/bin/bash
 cd {{.DDImgServerDir}}
 python3 -m  http.server 80`
+
+	// PasteldServerService - /etc/systemd/system/pasteld.service
+	PasteldServerService = `[Unit]
+Description=Pasteld Daemon
+
+[Service]
+ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIp}}
+
+[Install]
+WantedBy=multi-user.target
+`
 )
 
 // WalletNodeConfig defines configurations for walletnode
@@ -147,6 +158,12 @@ type DDImgServerServiceScript struct {
 // DDImgServerStartScript actual script to start dd image server
 type DDImgServerStartScript struct {
 	DDImgServerDir string
+}
+
+type PasteldServerServiceScript struct {
+	PasteldBinaryPath string
+	DataDir           string
+	ExternalIp        string
 }
 
 // ZksnarkParamsNames - slice of zksnark parameters

--- a/configs/config.go
+++ b/configs/config.go
@@ -101,17 +101,18 @@ WantedBy=multi-user.target
 cd {{.DDImgServerDir}}
 python3 -m  http.server 80`
 
-	// PasteldServerService - /etc/systemd/system/pasteld.service
-	PasteldServerService = `[Unit]
-Description=Pasteld Daemon
-
-[Service]
-User={{.User}}
-ExecStart={{.PasteldBinaryPath}} --datadir={{.DataDir}} --externalip={{.ExternalIP}}
-
-[Install]
-WantedBy=multi-user.target
-`
+	// SystemdService - /etc/systemd/sysstem/rq-service.service
+	SystemdService = `[Unit]
+	Description={{.Desc}}
+	
+	[Service]
+	WorkingDirectory={{.WorkDir}}
+	User={{.User}}
+	ExecStart={{.ExecCmd}}
+	
+	[Install]
+	WantedBy=multi-user.target
+	`
 )
 
 // WalletNodeConfig defines configurations for walletnode
@@ -161,12 +162,12 @@ type DDImgServerStartScript struct {
 	DDImgServerDir string
 }
 
-// PasteldServerServiceScript defines service file for /etc/systemd/system
-type PasteldServerServiceScript struct {
-	PasteldBinaryPath string
-	DataDir           string
-	ExternalIP        string
-	User              string
+// SystemdServiceScript defines service file for /etc/systemd/system
+type SystemdServiceScript struct {
+	User    string
+	ExecCmd string
+	Desc    string
+	WorkDir string
 }
 
 // ZksnarkParamsNames - slice of zksnark parameters

--- a/configs/init.go
+++ b/configs/init.go
@@ -16,6 +16,7 @@ type Init struct {
 	RemotePastelUtilityDir string `json:"remotepastelutilitydir,omitempty"`
 	CopyUtilityPath        string `json:"copy-utility,omitempty"`
 	StartedRemote          bool   `json:"started-remote,omitempty"`
+	StartedAsService       bool   `json:"started-asservice,omitempty"`
 }
 
 /*

--- a/configs/init.go
+++ b/configs/init.go
@@ -17,6 +17,7 @@ type Init struct {
 	CopyUtilityPath        string `json:"copy-utility,omitempty"`
 	StartedRemote          bool   `json:"started-remote,omitempty"`
 	StartedAsService       bool   `json:"started-asservice,omitempty"`
+	UserPw                 string `json:"user-pw,omitempty"`
 }
 
 /*

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -85,6 +85,11 @@ const (
 	// DupeDetectionServiceDir defines location for dupe detection service
 	DupeDetectionServiceDir = "pastel_dupe_detection_service"
 
+	// SystemdServicePrefix prefix of all pastel services
+	SystemdServicePrefix = "pastel-"
+	// SystemdSystemDir location of systemd folder in Linux system
+	SystemdSystemDir = "/etc/systemd/system"
+
 	// RQServiceDir defines location for rq-service file exchange dir
 	RQServiceDir = "rqfiles"
 	// P2PDataDir defines location for p2p data dir

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -60,6 +60,8 @@ const (
 	DDService ToolType = "dd-service"
 	// RQService type
 	RQService ToolType = "rq-service"
+	// DDImgService type
+	DDImgService ToolType = "dd-img-server"
 	// AMD64 is architecture type
 	AMD64 ArchitectureType = "amd64"
 	// DupeDetectionArchiveName is archive name for dupe detection


### PR DESCRIPTION
There are some improvements for pastel-utility:
- [x] When install walletnode with `./pastel-utility install walletnode -n=testnet`, perform question ask if user wants to install pasteld, rq-service, wallet node as service. If yes, create systemd service and enable/start that respective service.
- [x] When install walletnode with `./pastel-utility install walletnode -n=testnet`, perform question ask if user wants to install pasteld, rq-service, wallet node as service. If yes, create systemd service and enable/start that respective service.
- [x] Once start walletnode with `./pastel-utility start walletnode` - check if servcie is running. If no, then start respective service.
- [x] Add option `--started-as-service` - so there is no interaction needed
- [x] Stop systemd service if app is installed as service and is running. If not, close the service as normal
- [x] Start/stop node as service
- [x] Install supernode at remote side
- [ ] Validate checksum for downloading machine-learning files if they are existed

Checkout from PR#https://github.com/pastelnetwork/pastel-utility/pull/56