### PR TITLE
PSL-124 / Add systemd crash handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ In order to install all extra packages and set system services, `password` of cu
 - `--force, -f                 Optional, Force to overwrite config files and re-download ZKSnark parameters (default: false)`
 - `--peers value, -p value     Optional, List of peers to add into pastel.conf file, must be in the format - "ip" or "ip:port"`
 - `--release value, -r value   Optional, Pastel version to install (default: "beta")`
-- `--started-remote            Optional, means that this command is executed remotely via ssh shell`
-- `--started-as-service        Optional, start all apps automatically as systemd service`
+- `--enable-service            Optional, start all apps automatically as systemd service`
 - `--user-pw value             Optional, password of current sudo user - so no sudo password request is prompted`
 - `--help, -h                  show help (default: false)`
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -54,7 +54,7 @@ func setupSubCommand(config *configs.Config,
 			SetUsage(green("Optional, List of peers to add into pastel.conf file, must be in the format - \"ip\" or \"ip:port\"")),
 		cli.NewFlag("release", &config.Version).SetAliases("r").
 			SetUsage(green("Optional, Pastel version to install")).SetValue("beta"),
-		cli.NewFlag("started-as-service", &config.StartedAsService).
+		cli.NewFlag("enable-service", &config.EnableService).
 			SetUsage(green("Optional, start all apps automatically as systemd service")),
 		cli.NewFlag("user-pw", &config.UserPw).
 			SetUsage(green("Optional, password of current sudo user - so no sudo password request is prompted")),
@@ -312,6 +312,10 @@ func runInstallSuperNodeRemoteSubCommand(ctx context.Context, config *configs.Co
 		remoteOptions = fmt.Sprintf("%s -n=testnet", remoteOptions)
 	}
 
+	if config.EnableService {
+		remoteOptions = fmt.Sprintf("%s --enable-service", remoteOptions)
+	}
+
 	if len(sshPw) > 0 {
 		remoteOptions = fmt.Sprintf("%s --user-pw=%s", remoteOptions, sshPw)
 	}
@@ -451,7 +455,7 @@ func runComponentsInstall(ctx context.Context, config *configs.Config, installCo
 		}
 
 		// Start all wallet nodes apps as service
-		if config.StartedAsService {
+		if config.EnableService {
 			appServiceNames := []string{
 				string(constants.PastelD),
 				string(constants.RQService),
@@ -546,7 +550,7 @@ func runComponentsInstall(ctx context.Context, config *configs.Config, installCo
 		}
 
 		// installAppsAsService - pasteld, supernode, rq-server, dd-server
-		if config.StartedAsService {
+		if config.EnableService {
 			appServiceNames := []string{
 				string(constants.PastelD),
 				string(constants.RQService),
@@ -564,7 +568,7 @@ func runComponentsInstall(ctx context.Context, config *configs.Config, installCo
 	}
 
 	// Install node as service
-	if (installCommand == constants.PastelD) && (config.StartedAsService) {
+	if (installCommand == constants.PastelD) && (config.EnableService) {
 		if err := installAppService(ctx, string(constants.PastelD), config); err != nil {
 			log.WithContext(ctx).WithError(err).Error("Failed to install " + appName + " service")
 			return err

--- a/configs/config.go
+++ b/configs/config.go
@@ -84,18 +84,6 @@ processed_files_path = %s/
 internet_rareness_downloaded_images_path = %s/
 nsfw_model_path = %s/
 `
-
-	// DDImgServerService - /etc/systemd/system/dd_img_server.service
-	DDImgServerService = `[Unit]
-Description=Pastel dupe detection image service
-
-[Service]
-ExecStart={{.DDImgServerStartScript}}
-
-[Install]
-WantedBy=multi-user.target
-`
-
 	// DDImgServerStart - actual script to start dd image server - start_dd_img_server.sh
 	DDImgServerStart = `#!/bin/bash
 cd {{.DDImgServerDir}}
@@ -106,6 +94,8 @@ python3 -m  http.server 80`
 	Description={{.Desc}}
 	
 	[Service]
+	Restart=always
+	RestartSec=10
 	WorkingDirectory={{.WorkDir}}
 	User={{.User}}
 	ExecStart={{.ExecCmd}}

--- a/configs/init.go
+++ b/configs/init.go
@@ -16,7 +16,7 @@ type Init struct {
 	RemotePastelUtilityDir string `json:"remotepastelutilitydir,omitempty"`
 	CopyUtilityPath        string `json:"copy-utility,omitempty"`
 	StartedRemote          bool   `json:"started-remote,omitempty"`
-	StartedAsService       bool   `json:"started-asservice,omitempty"`
+	EnableService          bool   `json:"enableservice,omitempty"`
 	UserPw                 string `json:"user-pw,omitempty"`
 }
 


### PR DESCRIPTION
As supernode operator, all systemd service must handle crash and recover by itself, so no manually start is needed.

In any case, if app (supernode, node, walletnode, ... ) is killed or crashed, systemd will restart the service after 10 sec.