### PR TITLE
PSL-139 PSL-136: Add current height and total number of blocks to log message while waiting for remote node to sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ LDFLAGS="-s -w -X github.com/pastelnetwork/gonode/common/version.version=$(VERSI
 #
 release: $(PLATFORMS)
 
-# upx dist/$(BINARY)-$(os)-$(arch)
+# upx dist/$(BINARY)-$(os)-$(arch)$(ext
 $(PLATFORMS):
-	CGO_ENABLED=$(CGO) GOOS=$(os) GOARCH=$(arch) go build $(GCFLAGS) -ldflags=$(LDFLAGS) -o dist/$(BINARY)-$(os)-$(arch)$(ext) main.go
+	CGO_ENABLED=$(CGO) GOOS=$(os) GOARCH=$(arch) go build  $(GCFLAGS) -ldflags=$(LDFLAGS) -o dist/$(BINARY)-$(os)-$(arch)$(ext) main.go
 	upx dist/$(BINARY)-$(os)-$(arch)$(ext)
 
 .PHONY: release $(PLATFORMS)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -367,8 +367,20 @@ func StopPastelDAndWait(ctx context.Context, config *configs.Config) (err error)
 // CheckMasterNodeSync checks and waits until mnsync is "Finished", return number of synced blocks
 func CheckMasterNodeSync(ctx context.Context, config *configs.Config) (int, error) {
 	var getinfo structure.RPCGetInfo
+	var err error
 
 	for {
+		// Checking getinfo
+		log.WithContext(ctx).Info("Waiting for sync...")
+
+		getinfo, err = GetPastelInfo(ctx, config)
+		if err != nil {
+			log.WithContext(ctx).WithError(err).Error("master node getinfo call has failed")
+			return 0, err
+		}
+		log.WithContext(ctx).Infof("Loading blocks - block #%d; Node has %d connection", getinfo.Blocks, getinfo.Connections)
+
+		// Checking mnsync status
 		mnstatus, err := GetMNSyncInfo(ctx, config)
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("master node mnsync status call has failed")
@@ -386,14 +398,6 @@ func CheckMasterNodeSync(ctx context.Context, config *configs.Config) (int, erro
 			log.WithContext(ctx).Info("master node was synced!")
 			break
 		}
-		log.WithContext(ctx).Info("Waiting for sync...")
-
-		getinfo, err = GetPastelInfo(ctx, config)
-		if err != nil {
-			log.WithContext(ctx).WithError(err).Error("master node getinfo call has failed")
-			return 0, err
-		}
-		log.WithContext(ctx).Infof("Loading blocks - block #%d; Node has %d connection", getinfo.Blocks, getinfo.Connections)
 
 		time.Sleep(10 * time.Second)
 	}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -364,20 +364,21 @@ func StopPastelDAndWait(ctx context.Context, config *configs.Config) (err error)
 	return nil
 }
 
-// CheckMasterNodeSync checks and waits until mnsync is "Finished"
-func CheckMasterNodeSync(ctx context.Context, config *configs.Config) (err error) {
-	for {
+// CheckMasterNodeSync checks and waits until mnsync is "Finished", return number of synced blocks
+func CheckMasterNodeSync(ctx context.Context, config *configs.Config) (int, error) {
+	var getinfo structure.RPCGetInfo
 
+	for {
 		mnstatus, err := GetMNSyncInfo(ctx, config)
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("master node mnsync status call has failed")
-			return err
+			return 0, err
 		}
 
 		if mnstatus.AssetName == "Initial" {
 			if _, err = RunPastelCLI(ctx, config, "mnsync", "reset"); err != nil {
 				log.WithContext(ctx).WithError(err).Error("master node reset has failed")
-				return err
+				return 0, err
 			}
 			time.Sleep(10 * time.Second)
 		}
@@ -387,17 +388,17 @@ func CheckMasterNodeSync(ctx context.Context, config *configs.Config) (err error
 		}
 		log.WithContext(ctx).Info("Waiting for sync...")
 
-		getinfo, err := GetPastelInfo(ctx, config)
+		getinfo, err = GetPastelInfo(ctx, config)
 		if err != nil {
 			log.WithContext(ctx).WithError(err).Error("master node getinfo call has failed")
-			return err
+			return 0, err
 		}
 		log.WithContext(ctx).Infof("Loading blocks - block #%d; Node has %d connection", getinfo.Blocks, getinfo.Connections)
 
 		time.Sleep(10 * time.Second)
 	}
 
-	return nil
+	return getinfo.Blocks, nil
 }
 
 // CheckZksnarkParams validates Zksnark files

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1022,7 +1022,7 @@ func installAppService(ctx context.Context, appName string, config *configs.Conf
 		appBaseDir := filepath.Join(config.Configurer.DefaultHomeDir(), constants.DupeDetectionServiceDir)
 		appServiceWorkDirPath := filepath.Join(appBaseDir, "img_server")
 
-		execCmd = "python3 -m  http.server 80"
+		execCmd = "python3 -m  http.server 8080"
 		workDir = appServiceWorkDirPath
 
 	case string(constants.PastelD):

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -325,7 +325,7 @@ func runLocalSuperNodeSubCommand(ctx context.Context, config *configs.Config) er
 	}
 
 	// *************  4. Wait for blockchain and masternodes sync  *************
-	if err := CheckMasterNodeSync(ctx, config); err != nil {
+	if _, err := CheckMasterNodeSync(ctx, config); err != nil {
 		log.WithContext(ctx).WithError(err).Error("pasteld failed to synchronize, add some peers and try again")
 		return err
 	}
@@ -712,7 +712,7 @@ func prepareMasterNodeParameters(ctx context.Context, config *configs.Config) (e
 	}
 
 	// Check masternode status
-	if err = CheckMasterNodeSync(ctx, config); err != nil {
+	if _, err = CheckMasterNodeSync(ctx, config); err != nil {
 		log.WithContext(ctx).WithError(err).Error("pasteld failed to synchronize, add some peers and try again")
 		return err
 	}
@@ -873,9 +873,10 @@ func getMasternodeOutputs(ctx context.Context, config *configs.Config) (map[stri
 	return mnOutputs, nil
 }
 
-func checkCollateral(ctx context.Context, config *configs.Config) (err error) {
+func checkCollateral(ctx context.Context, config *configs.Config) error {
 
 	var address string
+	var err error
 
 	if len(flagMasterNodeTxID) == 0 || len(flagMasterNodeInd) == 0 {
 
@@ -886,7 +887,7 @@ func checkCollateral(ctx context.Context, config *configs.Config) (err error) {
 			yes, _ = AskUserToContinue(ctx, "Do you want to wait for local node to fully sync before searching? Y/N")
 			if yes {
 				log.WithContext(ctx).Info("Waiting for local node to fully sync before searching for collateral")
-				if err := CheckMasterNodeSync(ctx, config); err != nil {
+				if _, err = CheckMasterNodeSync(ctx, config); err != nil {
 					log.WithContext(ctx).WithError(err).Error("Failed to wait for local node to fully sync")
 					return err
 				}

--- a/cmd/start_coldhot.go
+++ b/cmd/start_coldhot.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -121,6 +122,7 @@ func (r *ColdHotRunner) handleConfigs(ctx context.Context) error {
 // Run starts coldhot runner
 func (r *ColdHotRunner) Run(ctx context.Context) (err error) {
 	isPasteldAlreadyRunning := false
+	var numOfSyncedBlocks int
 
 	// ***************  1. Start the local Pastel Network Node ***************
 	// Check if pasteld is already running
@@ -133,6 +135,13 @@ func (r *ColdHotRunner) Run(ctx context.Context) (err error) {
 			log.WithContext(ctx).WithError(err).Error("pasteld failed to start")
 			return err
 		}
+	}
+
+	// Wait the local node to be synced
+	log.WithContext(ctx).Infof("Waiting for local node to be synced")
+	if numOfSyncedBlocks, err = CheckMasterNodeSync(ctx, r.config); err != nil {
+		log.WithContext(ctx).WithError(err).Error("Failed to wait for local node to fully sync")
+		return err
 	}
 
 	// ***************  2. If flag --create or --update is provided ***************
@@ -151,18 +160,15 @@ func (r *ColdHotRunner) Run(ctx context.Context) (err error) {
 		}
 	}
 
-	// if err = StopPastelDAndWait(ctx, r.config); err != nil {
-	// 	log.WithContext(ctx).WithError(err).Error("unable to stop local node")
-	// 	return err
-	// }
-
 	// ***************  3. Execute following commands over SSH on the remote node (using ssh-ip and ssh-port)  ***************
 
-	if err = r.remoteHotNodeCtrl(ctx); err != nil {
-		log.WithContext(ctx).WithError(err).Error("failed on remoteHotNodeCtrl")
+	// Run pasteld at remote side and wait for it to be synced
+	log.WithContext(ctx).Infof("Starting pasteld at remote node and wait for it to be synced")
+	if err = r.runRemoteNode(ctx, numOfSyncedBlocks); err != nil {
+		log.WithContext(ctx).WithError(err).Error("failed on runRemoteNode")
 		return err
 	}
-	log.WithContext(ctx).Info("The hot wallet node has been successfully launched!")
+	log.WithContext(ctx).Infof("remote: pasteld is fully synced")
 
 	//Get conf data from masternode.conf File
 	privkey, _, _, err := getMasternodeConfData(ctx, r.config, flagMasterNodeName)
@@ -171,22 +177,29 @@ func (r *ColdHotRunner) Run(ctx context.Context) (err error) {
 	}
 	flagMasterNodePrivateKey = privkey
 
-	if err := r.runRemoteNodeAsMasterNode(ctx); err != nil {
+	if err := r.runRemoteNodeAsMasterNode(ctx, numOfSyncedBlocks); err != nil {
 		log.WithContext(ctx).WithError(err).Error("unable to run remote as masternode")
 		return fmt.Errorf("run remote as masternode: %s", err)
 	}
 	log.WithContext(ctx).Info("remote node started as masternode successfully..")
 
-	// log.WithContext(ctx).Info("restart cold node..")
-	// if err = runPastelNode(ctx, r.config, true, "", ""); err != nil {
-	// 	log.WithContext(ctx).WithError(err).Error("pasteld failed to start")
-	// 	return err
-	// }
+	// Restart pasteld at local node (cold node)
+	log.WithContext(ctx).Infof("Stopping pasteld at local node")
+	if err = StopPastelDAndWait(ctx, r.config); err != nil {
+		log.WithContext(ctx).WithError(err).Error("failed to stop pasteld")
+		return err
+	}
+
+	log.WithContext(ctx).Infof("Starting pasteld at local node")
+	if err = runPastelNode(ctx, r.config, true, "", ""); err != nil {
+		log.WithContext(ctx).WithError(err).Error("failed to start pasteld")
+		return err
+	}
 
 	// ***************  4. If --activate are provided, ***************
 	if flagMasterNodeIsActivate {
 		log.WithContext(ctx).Info("found --activate flag, checking local node sync..")
-		if err = CheckMasterNodeSync(ctx, r.config); err != nil {
+		if _, err = CheckMasterNodeSync(ctx, r.config); err != nil {
 			log.WithError(err).Error("local Masternode sync failure")
 			return err
 		}
@@ -247,7 +260,7 @@ func (r *ColdHotRunner) Run(ctx context.Context) (err error) {
 	return nil
 }
 
-func (r *ColdHotRunner) runRemoteNodeAsMasterNode(ctx context.Context) error {
+func (r *ColdHotRunner) runRemoteNodeAsMasterNode(ctx context.Context, numOfSyncedBlocks int) error {
 	go func() {
 		cmdLine := fmt.Sprintf("%s --masternode --txindex=1 --reindex --masternodeprivkey=%s --externalip=%s  --data-dir=%s %s --daemon ",
 			r.opts.remotePasteld, flagMasterNodePrivateKey, flagNodeExtIP, r.config.RemoteWorkingDir, r.opts.testnetOption)
@@ -265,7 +278,7 @@ func (r *ColdHotRunner) runRemoteNodeAsMasterNode(ctx context.Context) error {
 		return err
 	}
 
-	if err := r.checkMasterNodeSyncRemote(ctx, 0); err != nil {
+	if err := r.checkMasterNodeSyncRemote(ctx, numOfSyncedBlocks, 0); err != nil {
 		log.WithContext(ctx).Error("Remote::Master node sync failed")
 		return err
 	}
@@ -274,12 +287,15 @@ func (r *ColdHotRunner) runRemoteNodeAsMasterNode(ctx context.Context) error {
 }
 
 func (r *ColdHotRunner) handleCreateUpdateStartColdHot(ctx context.Context) error {
-	if err := checkCollateral(ctx, r.config); err != nil {
+	var err error
+
+	// Check Collateral for cold node
+	if err = checkCollateral(ctx, r.config); err != nil {
 		log.WithContext(ctx).WithError(err).Error("Missing collateral transaction")
 		return err
 	}
 
-	if err := checkPassphrase(ctx); err != nil {
+	if err = checkPassphrase(ctx); err != nil {
 		log.WithContext(ctx).WithError(err).Error("Missing passphrase")
 		return err
 	}
@@ -297,17 +313,17 @@ func (r *ColdHotRunner) handleCreateUpdateStartColdHot(ctx context.Context) erro
 		return errors.New("unable to start pasteld on remote")
 	}
 
-	if err := checkMasternodePrivKey(ctx, r.config, r.sshClient); err != nil {
+	if err = checkMasternodePrivKey(ctx, r.config, r.sshClient); err != nil {
 		log.WithContext(ctx).WithError(err).Error("Missing masternode private key")
 		return err
 	}
 
-	if err := checkPastelID(ctx, r.config, r.sshClient); err != nil {
+	if err = checkPastelID(ctx, r.config, r.sshClient); err != nil {
 		log.WithContext(ctx).WithError(err).Error("Missing masternode PastelID")
 		return err
 	}
 
-	if _, err := r.sshClient.Cmd(fmt.Sprintf("%s stop", r.opts.remotePastelCli)).Output(); err != nil {
+	if _, err = r.sshClient.Cmd(fmt.Sprintf("%s stop", r.opts.remotePastelCli)).Output(); err != nil {
 		log.WithContext(ctx).Error("Error - stopping on remote pasteld")
 		return err
 	}
@@ -315,7 +331,7 @@ func (r *ColdHotRunner) handleCreateUpdateStartColdHot(ctx context.Context) erro
 	time.Sleep(5 * time.Second)
 
 	if flagMasterNodeIsCreate {
-		if _, err := backupConfFile(ctx, r.config); err != nil {
+		if _, err = backupConfFile(ctx, r.config); err != nil {
 			log.WithContext(ctx).WithError(err).Error("Failed to backup masternode.conf")
 			return err
 		}
@@ -370,7 +386,7 @@ func CheckPastelDRunningRemote(ctx context.Context, client *utils.Client, cliPat
 	return true
 }
 
-func (r *ColdHotRunner) remoteHotNodeCtrl(ctx context.Context) error {
+func (r *ColdHotRunner) runRemoteNode(ctx context.Context, numOfSyncedBlocks int) error {
 	go func() {
 		if err := r.sshClient.Cmd(fmt.Sprintf("%s --reindex --externalip=%s --data-dir=%s --daemon %s",
 			r.opts.remotePasteld, flagNodeExtIP, r.config.RemoteWorkingDir, r.opts.testnetOption)).Run(); err != nil {
@@ -382,7 +398,7 @@ func (r *ColdHotRunner) remoteHotNodeCtrl(ctx context.Context) error {
 		return fmt.Errorf("unable to start pasteld on remote")
 	}
 
-	if err := r.checkMasterNodeSyncRemote(ctx, 0); err != nil {
+	if err := r.checkMasterNodeSyncRemote(ctx, numOfSyncedBlocks, 0); err != nil {
 		log.WithContext(ctx).Error("Remote::Master node sync failed")
 		return err
 	}
@@ -396,11 +412,13 @@ func (r *ColdHotRunner) remoteHotNodeCtrl(ctx context.Context) error {
 	return nil
 }
 
-func (r *ColdHotRunner) checkMasterNodeSyncRemote(ctx context.Context, retryCount int) (err error) {
+func (r *ColdHotRunner) checkMasterNodeSyncRemote(ctx context.Context, numOfSyncedBlocks int, retryCount int) (err error) {
 	var mnstatus structure.RPCPastelMSStatus
 	var output []byte
+	var blockcount int
 
 	for {
+		// Get mnsync status
 		if output, err = r.sshClient.Cmd(fmt.Sprintf("%s mnsync status", r.opts.remotePastelCli)).Output(); err != nil {
 			log.WithContext(ctx).WithField("out", string(output)).WithError(err).
 				Error("Remote:::failed to get mnsync status")
@@ -408,12 +426,12 @@ func (r *ColdHotRunner) checkMasterNodeSyncRemote(ctx context.Context, retryCoun
 				log.WithContext(ctx).WithError(err).Error("retrying mynsyc staus...")
 				time.Sleep(5 * time.Second)
 
-				return r.checkMasterNodeSyncRemote(ctx, 1)
+				return r.checkMasterNodeSyncRemote(ctx, numOfSyncedBlocks, 1)
 			}
 
 			return err
 		}
-		// Master Node Output
+
 		if err = json.Unmarshal([]byte(output), &mnstatus); err != nil {
 			log.WithContext(ctx).WithField("payload", string(output)).WithError(err).
 				Error("Remote:::failed to unmarshal mnsync status")
@@ -434,7 +452,21 @@ func (r *ColdHotRunner) checkMasterNodeSyncRemote(ctx context.Context, retryCoun
 			log.WithContext(ctx).Info("Remote:::master node was synced!")
 			break
 		}
-		log.WithContext(ctx).Info("Remote:::Waiting for sync...")
+
+		// Get blockcount at remote: `pasteld getinfo`
+		if output, err = r.sshClient.Cmd(fmt.Sprintf("%s getblockcount", r.opts.remotePastelCli)).Output(); err != nil {
+			log.WithContext(ctx).WithField("out", string(output)).WithError(err).
+				Error("Remote:::failed to get blockcount")
+			return err
+		}
+
+		if blockcount, err = strconv.Atoi(string(output)); err != nil {
+			log.WithContext(ctx).WithField("out", string(output)).WithError(err).
+				Error("Remote:::failed to convert blockcount to int")
+			return err
+		}
+
+		log.WithContext(ctx).Infof("Remote:::Waiting for sync... (%d from %d)", blockcount, numOfSyncedBlocks)
 		time.Sleep(10 * time.Second)
 	}
 	return nil

--- a/cmd/start_coldhot.go
+++ b/cmd/start_coldhot.go
@@ -151,10 +151,10 @@ func (r *ColdHotRunner) Run(ctx context.Context) (err error) {
 		}
 	}
 
-	if err = StopPastelDAndWait(ctx, r.config); err != nil {
-		log.WithContext(ctx).WithError(err).Error("unable to stop local node")
-		return err
-	}
+	// if err = StopPastelDAndWait(ctx, r.config); err != nil {
+	// 	log.WithContext(ctx).WithError(err).Error("unable to stop local node")
+	// 	return err
+	// }
 
 	// ***************  3. Execute following commands over SSH on the remote node (using ssh-ip and ssh-port)  ***************
 
@@ -177,11 +177,11 @@ func (r *ColdHotRunner) Run(ctx context.Context) (err error) {
 	}
 	log.WithContext(ctx).Info("remote node started as masternode successfully..")
 
-	log.WithContext(ctx).Info("restart cold node..")
-	if err = runPastelNode(ctx, r.config, true, "", ""); err != nil {
-		log.WithContext(ctx).WithError(err).Error("pasteld failed to start")
-		return err
-	}
+	// log.WithContext(ctx).Info("restart cold node..")
+	// if err = runPastelNode(ctx, r.config, true, "", ""); err != nil {
+	// 	log.WithContext(ctx).WithError(err).Error("pasteld failed to start")
+	// 	return err
+	// }
 
 	// ***************  4. If --activate are provided, ***************
 	if flagMasterNodeIsActivate {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -298,7 +298,7 @@ var DependenciesPackagesWalletNode = map[OSType][]string{
 
 // DependenciesPackagesSuperNode defines some dependencies for supernode
 var DependenciesPackagesSuperNode = map[OSType][]string{
-	Linux:   {"libgomp1", "ufw", "python3-pip"},
+	Linux:   {"libgomp1", "ufw", "python3-pip", "curl"},
 	Mac:     {},
 	Windows: {},
 	Unknown: {},

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -231,6 +231,12 @@ func Untar(dst string, r io.Reader, filenames ...string) error {
 	for {
 		header, err := tr.Next()
 
+		// validate filenames
+		p, _ := filepath.Abs(header.Name)
+		if strings.Contains(p, "..") {
+			return errors.Errorf("invalid tar file")
+		}
+
 		switch {
 		// if no more files are found return
 		case err == io.EOF:


### PR DESCRIPTION
- [x]  Fix missing "curl" pkg when running coldhot at remoteside
- [x]  Change dd-img-server from 80 --> 8080
- [x]  Fix security bug - when untar
- [x]  When starting cold-hot: does not stop and restart pasteld at cold node
- [x] Add current height and total number of block - while waiting remote sync
- [x] Restart local node - after started remote node as masternode