### PR TITLE
[No-Jira] Improve pastelup cold-hot and remote tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,20 @@ c) In case `--bin` is missing, the tool will update the latest from the download
    --user-pw=<pw of remote user>
 ```
 
+### Start supernode-coldhot
+
+How cold-hot is working: https://pastel.wiki/en/home/how-to-start-mn
+
+Usage:
+```
+./pastel-utility start supernode-coldhot \
+   --ssh-ip 10.211.55.5 \
+   --ssh-user bacnh \
+   --ssh-key=$HOME/.ssh/id_rsa 
+   --name=mn01 
+   --create
+```
+
 ### Install command options
 
 `pastelup install <node|walletnode|supernode> ...` supports the following common parameters:

--- a/README.md
+++ b/README.md
@@ -121,19 +121,19 @@ The above command will:
 
 In order to install all extra packages and set system services, `password` of current user with `sudo` access is needed via param `--ssh-user-pw`.
 
+Below is example to create supernode with `testnet` network:
 ```
 ./pastelup install supernode remote \
   --ssh-ip <remote_ip> \
-  --ssh-dir=<path_remote_utility_folder>/ \
-  --utility-path-to-copy=<path_local_pastelup> \
   --ssh-user=<remote username> \
   --ssh-user-pw=<remote_user_pw> \
-  --ssh-key=$HOME/.ssh/id_rsa 
+  --ssh-key=$HOME/.ssh/id_rsa \
+  -n=testnet \
+  --force
 ```
+### Update supernode remotely
 
-## Update supernode remotely
-
-### Usage
+#### Usage
 ```
 NAME:
    pastelup update supernode remote - 
@@ -150,7 +150,6 @@ OPTIONS:
    --ssh-port value            Optional, SSH port of the remote host, default is 22 (default: 22)
    --ssh-user value            Optional, Username of user at remote host
    --ssh-key value             Optional, Path to SSH private key for SSH Key Authentication
-   --utility-path value        Required, local path of pastelup file 
    --bin value                 Required, local path to the local binary (pasteld, pastel-cli, rq-service, supernode) file  or a folder of binary to remote host
    --help, -h                  show help (default: false)
 ```
@@ -164,7 +163,6 @@ a) To update supernode bin to remote side:
 
 ```
 ./pastelup update supernode remote \
-  --utility-path=$HOME/pastel/pastelup \
   --bin=$HOME/pastel/supernode-ubuntu20.04-amd64 \
   --name=<masternode name> \
   --ssh-ip=<remote ip> \
@@ -174,8 +172,7 @@ a) To update supernode bin to remote side:
 ```
 b) To update all binaries at once. Create a local folder and copy all binaries into a folder and execute below command with `--bin` points to that folder path:
 ```
-./pastelup update supernode remote \
-  --utility-path=$HOME/pastel/pastelup \
+./pastelup update supernode remote \ 
   --bin=<path fo that folder> \
   --name=<masternode name> \
   --ssh-ip=<remote ip> \
@@ -186,12 +183,12 @@ b) To update all binaries at once. Create a local folder and copy all binaries i
 c) In case `--bin` is missing, the tool will update the latest from the download page
 
 ```
-./pastelup update supernode remote  --utility-path=$HOME/pastel/pastelup \
+./pastelup update supernode remote  \
    --name=<masternode name> \
    --ssh-ip <remote ip> \
    --ssh-user <remote username> \
-   --user-pw <remote_user_pw> \
-   --ssh-key=$HOME/.ssh/id_rsa
+   --ssh-key=$HOME/.ssh/id_rsa \
+   --user-pw=<pw of remote user>
 ```
 
 ### Install command options

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -457,7 +457,7 @@ func copyPastelUpToRemote(ctx context.Context, client *utils.Client, remotePaste
 		// Get local pastelup path
 		ex, err := os.Executable()
 		if err != nil {
-			return fmt.Errorf("failure in getting path of executable file %s", err)
+			return fmt.Errorf("failed to get path of executable file %s", err)
 		}
 
 		// Check if localPastelupPath is a symlink file
@@ -467,26 +467,26 @@ func copyPastelUpToRemote(ctx context.Context, client *utils.Client, remotePaste
 
 		// Copy pastelup to remote
 		if err := client.Scp(localPastelupPath, remotePastelUp); err != nil {
-			return fmt.Errorf("failure in copying pastelup to remote %s", err)
+			return fmt.Errorf("failed to copy pastelup to remote %s", err)
 		}
 
 	} else {
-		log.WithContext(ctx).Infof("Current OS is not linux, skipping pastelup copy")
+		log.WithContext(ctx).Infof("current OS is not linux, skipping pastelup copy")
 
 		// Download PastelUpExecName from remote and save to remotePastelUp
-		log.WithContext(ctx).Infof("Downloading pastelup from Pastel download portal ...")
+		log.WithContext(ctx).Infof("downloading pastelup from Pastel download portal ...")
 		version := "beta"
 		downloadURL := fmt.Sprintf("%s/%s/%s", constants.DownloadBaseURL, version, constants.PastelUpExecName["Linux"])
 
 		if _, err := client.Cmd(fmt.Sprintf("wget %s -O %s", downloadURL, remotePastelUp)).Output(); err != nil {
-			return fmt.Errorf("failure in downloading pastelup from remote: %s", err.Error())
+			return fmt.Errorf("failed to download pastelup from remote: %s", err.Error())
 		}
 		log.WithContext(ctx).Infof("pastelup downloaded from Pastel download portal")
 	}
 
-	// chmod +x pastelup at remote
+	// chmod +x remote pastelup
 	if _, err := client.Cmd(fmt.Sprintf("chmod +x %s", remotePastelUp)).Output(); err != nil {
-		return fmt.Errorf("failure in chmod +x pastelup at remote: %s", err.Error())
+		return fmt.Errorf("failed to chmod +x pastelup at remote: %s", err.Error())
 	}
 
 	return nil

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -317,7 +317,7 @@ func runComponentsInstall(ctx context.Context, config *configs.Config, installCo
 		if !utils.IsValidNetworkOpt(config.Network) {
 			return fmt.Errorf("invalid --network provided. valid opts: %s", strings.Join(constants.NetworkModes, ","))
 		}
-		log.WithContext(ctx).Infof("initiaing in %s mode", config.Network)
+		log.WithContext(ctx).Infof("initiating in %s mode", config.Network)
 	}
 
 	// create installation directory, example ~/pastel

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -131,10 +131,8 @@ func setupStartSubCommand(config *configs.Config,
 			SetUsage(yellow("Optional, SSH user")),
 		cli.NewFlag("ssh-key", &sshKey).
 			SetUsage(yellow("Optional, Path to SSH private key")),
-		cli.NewFlag("ssh-dir", &config.RemotePastelUtilityDir).SetAliases("rpud").
-			SetUsage(yellow("Required, Location where to copy pastel-utility on the remote computer")).SetRequired(),
 		cli.NewFlag("remote-dir", &config.RemotePastelExecDir).
-			SetUsage(green("Optional, Location where of pastel node directory on the remote computer (default: $HOME/pastel-utility)")),
+			SetUsage(green("Optional, Location where of pastel node directory on the remote computer (default: $HOME/pastel)")),
 		cli.NewFlag("remote-work-dir", &config.RemoteWorkingDir).
 			SetUsage(green("Optional, Location of working directory on the remote computer (default: $HOME/.pastel")).SetValue("$HOME/.pastel"),
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -893,15 +893,6 @@ func checkCollateral(ctx context.Context, config *configs.Config) error {
 		yes, _ := AskUserToContinue(ctx, "Search existing masternode collateral ready transaction in the wallet? Y/N")
 
 		if yes {
-			yes, _ = AskUserToContinue(ctx, "Do you want to wait for local node to fully sync before searching? Y/N")
-			if yes {
-				log.WithContext(ctx).Info("Waiting for local node to fully sync before searching for collateral")
-				if _, err = CheckMasterNodeSync(ctx, config); err != nil {
-					log.WithContext(ctx).WithError(err).Error("Failed to wait for local node to fully sync")
-					return err
-				}
-			}
-
 			var mnOutputs map[string]string
 			mnOutputs, err = getMasternodeOutputs(ctx, config)
 			if err != nil {

--- a/cmd/start_coldhot.go
+++ b/cmd/start_coldhot.go
@@ -74,7 +74,7 @@ func (r *ColdHotRunner) Init(ctx context.Context) error {
 
 	// Copy pastelup to remote
 	if err := copyPastelUpToRemote(ctx, client, r.opts.remotePastelUp); err != nil {
-		return fmt.Errorf("failure in copying pastelup to remote %s", err)
+		return fmt.Errorf("failed to copy pastelup to remote %s", err)
 	}
 
 	return nil

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -114,6 +114,9 @@ const (
 
 	// TempDir defines temporary directory
 	TempDir = "tmp"
+
+	// RemotePastelupPath - Remote pastelup path
+	RemotePastelupPath = "/tmp/pastelup"
 )
 
 // ServiceName defines services name

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -33,12 +33,6 @@ const (
 	// DupeDetectionImageFingerPrintDataBase - dupe_detection_image_fingerprint_database file
 	DupeDetectionImageFingerPrintDataBase string = "dupe_detection_image_fingerprint_database.sqlite"
 
-	// PastelUtilityDownloadURL - The path of pastel-utility for install supernode remote
-	PastelUtilityDownloadURL string = "https://github.com/pastelnetwork/pastel-utility/releases/download/v0.5.8/pastel-utility-linux-amd64"
-
-	// RequirementDownloadURL - The path of requirement.txt for install pip
-	RequirementDownloadURL string = "https://download.pastel.network/machine-learning/requirements.txt"
-
 	// Windows type
 	Windows OSType = "Windows"
 	// Linux type
@@ -157,6 +151,13 @@ var SuperNodeExecName = map[OSType]string{
 	Linux:   "supernode-ubuntu20.04-amd64",
 	Mac:     "",
 	Unknown: "",
+}
+
+// PastelUpExecName - The name of the pastelup
+var PastelUpExecName = map[OSType]string{
+	Windows: "pastel-utility-windows-amd64.exe",
+	Linux:   "pastel-utility-ubuntu20.04-amd64",
+	Mac:     "pastel-utility-darwin-amd64",
 }
 
 // PastelExecArchiveName - The name of the pastel executable files


### PR DESCRIPTION
- [x] start cold-hot: copy pastelup itself to remote side at /tmp/pastelup
- [x] improve start cold-got sequence (restart local pasteld)
- [x] improve other remote task to copy itself to remote side -- remove all related pastelup path in commands
- [x] improve update - check if pasteld is running then stop all services and then restart it later. If not, just only update the service components (node, supernode, walletnode)
- [x] If running OS is not Linux, then download pastelup from the Download portal to use in the remote host