### PR TITLE
[No-JIRA] add installing google-chrome-stable via google apt

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -593,7 +593,7 @@ func installMissingReqPackagesLinux(ctx context.Context, config *configs.Config,
 	// Add google ssl key
 	log.WithContext(ctx).Info("Adding google ssl key ...")
 
-	_, err = RunCMD("bash", "-c", "wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub > /tmp/google-key.pub")
+	_, err = RunCMD("bash", "-c", "wget -q -O - "+constants.GooglePubKeyURL+" > /tmp/google-key.pub")
 	if err != nil {
 		log.WithContext(ctx).WithError(err).Error("Write /tmp/google-key.pub failed")
 		return err
@@ -612,19 +612,19 @@ func installMissingReqPackagesLinux(ctx context.Context, config *configs.Config,
 
 	// Add google repo: /etc/apt/sources.list.d/google-chrome.list
 	log.WithContext(ctx).Info("Adding google ppa repo ...")
-	_, err = RunCMD("bash", "-c", "echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /tmp/google-chrome.list")
+	_, err = RunCMD("bash", "-c", "echo '"+constants.GooglePPASourceList+"' | tee /tmp/google-chrome.list")
 	if err != nil {
 		log.WithContext(ctx).WithError(err).Error("Failed to create /tmp/google-chrome.list")
 		return err
 	}
 
 	if len(config.UserPw) > 0 {
-		_, err = RunCMD("bash", "-c", "echo "+config.UserPw+" | sudo -S mv /tmp/google-chrome.list /etc/apt/sources.list.d/ 2>/dev/null")
+		_, err = RunCMD("bash", "-c", "echo "+config.UserPw+" | sudo -S mv /tmp/google-chrome.list "+constants.UbuntuSourceListPath+" 2>/dev/null")
 	} else {
-		_, err = RunCMD("bash", "-c", "sudo mv /tmp/google-chrome.list /etc/apt/sources.list.d/")
+		_, err = RunCMD("bash", "-c", "sudo mv /tmp/google-chrome.list "+constants.UbuntuSourceListPath+" 2>/dev/null")
 	}
 	if err != nil {
-		log.WithContext(ctx).WithError(err).Error("Failed to move /tmp/google-chrome.list to /etc/apt/sources.list.d/")
+		log.WithContext(ctx).WithError(err).Error("Failed to move /tmp/google-chrome.list to " + constants.UbuntuSourceListPath)
 		return err
 	}
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -201,6 +201,15 @@ var PastelParamsCheckSums = map[string]string{
 	"sprout-verifying.key":  "4bd498dae0aacfd8e98dc306338d017d9c08dd0918ead18172bd0aec2fc5df82",
 }
 
+// GooglePubKeyURL - The url of the google public key
+var GooglePubKeyURL = "https://dl-ssl.google.com/linux/linux_signing_key.pub"
+
+// GooglePPASourceList - The url of the google PPA source list
+var GooglePPASourceList = "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
+
+// UbuntuSourceListPath - The path of the ubuntu source list
+var UbuntuSourceListPath = "/etc/apt/sources.list.d"
+
 // MainnetPortList - PortList of supernode
 var MainnetPortList = []int{9933, 4444, 4445, 4446, 4447}
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -201,22 +201,6 @@ var PastelParamsCheckSums = map[string]string{
 	"sprout-verifying.key":  "4bd498dae0aacfd8e98dc306338d017d9c08dd0918ead18172bd0aec2fc5df82",
 }
 
-// ChromeDownloadURL - The download url of chrome
-var ChromeDownloadURL = map[OSType]string{
-	Windows: "",
-	Linux:   "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb",
-	Mac:     "",
-	Unknown: "",
-}
-
-// ChromeExecFileName - The download filename of chrome executable
-var ChromeExecFileName = map[OSType]string{
-	Windows: "",
-	Linux:   "google-chrome.deb",
-	Mac:     "",
-	Unknown: "",
-}
-
 // MainnetPortList - PortList of supernode
 var MainnetPortList = []int{9933, 4444, 4445, 4446, 4447}
 
@@ -313,7 +297,7 @@ var DependenciesPackagesWalletNode = map[OSType][]string{
 
 // DependenciesPackagesSuperNode defines some dependencies for supernode
 var DependenciesPackagesSuperNode = map[OSType][]string{
-	Linux:   {"libgomp1", "ufw", "python3-pip", "curl"},
+	Linux:   {"libgomp1", "ufw", "python3-pip", "curl", "google-chrome-stable"},
 	Mac:     {},
 	Windows: {},
 	Unknown: {},

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -427,14 +427,14 @@ func GetInstalledPackages(ctx context.Context) map[string]bool {
 	m := make(map[string]bool)
 	switch GetOS() {
 	case constants.Linux:
-		cmd := exec.Command("dpkg-query", "-f", "${binary:Package} ", "-W")
+		cmd := exec.Command("bash", "-c", "dpkg-query -l | grep ii | awk '{ print $2 }'")
 		stdout, err := cmd.Output()
 		if err != nil {
 			log.WithContext(ctx).Errorf("failed to execute cmd: %v", err)
 			return m
 		}
 
-		packages := strings.Split(string(stdout), " ")
+		packages := strings.Split(string(stdout), "\n")
 		for _, p := range packages {
 			tokens := strings.Split(p, ":")
 			if tokens[0] != "" {


### PR DESCRIPTION
1) Remove installed google-chrome-stable via:

```
sudo dpkg -P google-chrome-stable
```

2) Test again supernode install, update
```
./pastelup install supernode -n=testnet
```

And update:

```
./pastelup update supernode -m=mn1
```


Tested:

- [x] Install supernode locally with/without `--user-pw`
- [x] Install supernode remotely
- [x] Update supernode locally
- [x] Update supernode remotely
- [x] Fix bug where dpkg does not list not installed pkg it is still in db
- [x] When doing update - will upgrade listed packages