### PR TITLE
fix bug when installing dupedetection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 pastel-cli
 pastel-utility
+pastelup
 pasteld
 pastel
 dist/

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -715,6 +715,13 @@ func installMissingReqPackagesLinux(ctx context.Context, config *configs.Config,
 }
 
 func downloadComponents(ctx context.Context, config *configs.Config, installCommand constants.ToolType, version string, dstFolder string) (err error) {
+	if _, err := os.Stat(config.PastelExecDir); os.IsNotExist(err) {
+		if err := utils.CreateFolder(ctx, config.PastelExecDir, config.Force); err != nil {
+			log.WithContext(ctx).WithError(err).Errorf("create folder: %s", config.PastelExecDir)
+			return err
+		}
+	}
+
 	commandName := filepath.Base(string(installCommand))
 	log.WithContext(ctx).Infof("Downloading %s...", commandName)
 


### PR DESCRIPTION
 If ~/pastel folder is not exist, then it will failed to download dupedetection package

Test:
- Delete ~/pastel folder
- install dupedetection only with `pastelup install dupedetection`