### PR TITLE
WIP: enhance update command

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -103,6 +103,26 @@ func ParsePastelConf(ctx context.Context, config *configs.Config) error {
 	return nil
 }
 
+// GetProcessCmdInput gets the arguments of a process. returns true if it was running and false if it wasnt or there was an error
+func GetProcessCmdInput(toolType constants.ToolType) (bool, []string) {
+	var cmdArgs []string
+	pid, err := GetRunningProcessPid(toolType)
+	if err != nil {
+		return false, cmdArgs
+	}
+	output, err := RunCMD("bash", "-c", fmt.Sprintf("ps -o args= -f -p %v", pid))
+	if err != nil {
+		return false, cmdArgs
+	}
+	args := strings.Split(output, " ")
+	for i, arg := range args {
+		if i != 0 && arg != "" {
+			cmdArgs = append(cmdArgs, strings.Trim(arg, "\n"))
+		}
+	}
+	return true, cmdArgs
+}
+
 // CheckProcessRunning checks if the process is running
 func CheckProcessRunning(toolType constants.ToolType) bool {
 	if pid, err := GetRunningProcessPid(toolType); pid != 0 && err == nil {
@@ -521,4 +541,13 @@ func prepareRemoteSession(ctx context.Context, config *configs.Config) (*utils.C
 	log.WithContext(ctx).Info("successfully install pastelup executable to remote host")
 
 	return client, nil
+}
+
+func mergeCmdArgs(srcArgs []string, additionalArgs []string) []string {
+	for _, arg := range additionalArgs {
+		if !utils.Contains(srcArgs, arg) {
+			srcArgs = append(srcArgs, arg)
+		}
+	}
+	return srcArgs
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -580,7 +580,7 @@ func runWalletNodeService(ctx context.Context, config *configs.Config) error {
 		if flagDevMode {
 			wnServiceArgs = append(wnServiceArgs, "--swagger")
 		}
-
+		wnServiceArgs = mergeCmdArgs(wnServiceArgs, config.Configurer.GetOriginalArgs(constants.WalletNode))
 		log.WithContext(ctx).Infof("Options : %s", wnServiceArgs)
 		if err := runPastelService(ctx, config, constants.WalletNode, walletnodeExecName, wnServiceArgs...); err != nil {
 			log.WithContext(ctx).WithError(err).Error("walletnode service failed")

--- a/configurer/configurer.go
+++ b/configurer/configurer.go
@@ -28,6 +28,7 @@ type configurer struct {
 	homeDir             string
 	architecture        constants.ArchitectureType
 	osType              constants.OSType
+	originalArgs        map[constants.ToolType][]string
 }
 
 // GetHomeDir returns the home path.
@@ -73,6 +74,18 @@ func (c *configurer) DefaultZksnarkDir() string {
 // DefaultPastelExecutableDir returns the default pastel executable path.
 func (c *configurer) DefaultPastelExecutableDir() string {
 	return filepath.Join(c.DefaultHomeDir(), filepath.FromSlash(getAppDir()), c.pastelExecutableDir)
+}
+
+func (c *configurer) SetOriginalArgs(tooltype constants.ToolType, args []string) {
+	c.originalArgs[tooltype] = args
+}
+
+func (c *configurer) GetOriginalArgs(tooltype constants.ToolType) []string {
+	args, ok := c.originalArgs[tooltype]
+	if !ok {
+		return []string{}
+	}
+	return args
 }
 
 // GetDownloadURL returns download url of the pastel executables.

--- a/configurer/interface.go
+++ b/configurer/interface.go
@@ -18,4 +18,6 @@ type IConfigurer interface {
 	GetWalletNodeConfFile(workingDir string) string
 	GetRQServiceConfFile(workingDir string) string
 	GetDownloadURL(version string, tool constants.ToolType) (*url.URL, string, error)
+	SetOriginalArgs(tooltype constants.ToolType, args []string)
+	GetOriginalArgs(tooltype constants.ToolType) []string
 }


### PR DESCRIPTION
As of right now, this adds support for:
* persisting the original command line args of a given command (i.e. `./pastelup start walletnode {commands...}`) 
* Applying the persisted commands when restarting the tool by merging default commands + custom ones
* support for running update `dd-service` and `rq-service` as standalone commands
* Copying the working dir by creating a pastel_archives folder and copying the contents of the working dir to a timestamped folder in that dir before running update

Notes:
* still need to cleanup coding style and align to existing style
* add rest of logic described in PSL-257